### PR TITLE
Rcb 380 php 429s

### DIFF
--- a/source/rosette/api/CustomException.php
+++ b/source/rosette/api/CustomException.php
@@ -58,7 +58,7 @@ class CustomException extends \Exception implements IException
             throw new $this('Unknown ' . get_class($this));
         }
         $code = is_numeric($code) ? $code : 0;
-        parent::__construct($message, $code);
+        parent::__construct("[${code}]: ${message}", $code);
     }
 
     /**

--- a/source/rosette/api/RosetteRequest.php
+++ b/source/rosette/api/RosetteRequest.php
@@ -1,0 +1,278 @@
+<?php
+
+/**
+ * class RosetteRequest.
+ *
+ * Wrapper class for php Curl
+ *
+ * @copyright 2014-2016 Basis Technology Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * @license http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ **/
+namespace rosette\api;
+
+/**
+ * Class RosetteRequest.
+ *
+ * Wraps the php curl commands into an easier to use (and mock) object
+ */
+class RosetteRequest
+{
+    /**
+     * API URL
+     *
+     * @var string
+     */
+    private $url;
+    /**
+     * Request data
+     *
+     * @var string
+     */
+    private $data;
+    /**
+     * Request headers
+     *
+     * @var string
+     */
+    private $headers;
+    /**
+     * POST or GET
+     *
+     * @var string
+     */
+    private $method;
+    /**
+     * PHP curl handle
+     *
+     * @var mixed
+     */
+    private $curl_handle;
+    /**
+     * Response object
+     *
+     * @var mixed
+     */
+    private $response;
+    /**
+     * indicates that curl is initialized
+     *
+     * @var bool
+     */
+    private $initialized;
+
+    /**
+     * class constructor
+     *
+     */
+    public function __construct()
+    {
+        $this->initialized = false;
+    }
+
+    /**
+     * class destructor
+     */
+    public function __destruct()
+    {
+        if ($this->initialized) {
+            curl_close($this->curl_handle);
+            $this->initialized = false;
+        }
+    }
+
+    /**
+     * Wraps the curl call
+     *
+     * @param string $url URL of the Api API
+     * @param string $data Response data
+     * @param string $headers Response headers
+     * @param string $method GET or POST
+     *
+     * @return bool
+     */
+    public function makeRequest($url, $headers, $data, $method)
+    {
+        if ($this->initialized === true) {
+            curl_reset($this->curl_handle);
+        } else {
+            $this->curl_handle = curl_init();
+            $this->initialized = true;
+        }
+
+        curl_setopt($this->curl_handle, CURLOPT_URL, $url);
+        curl_setopt($this->curl_handle, CURLOPT_HTTPHEADER, $headers);
+
+        if ($method === 'POST') {
+            curl_setopt($this->curl_handle, CURLOPT_POST, true);
+            curl_setopt($this->curl_handle, CURLOPT_POSTFIELDS, $data);
+        } elseif ($method === 'GET') {
+            curl_setopt($this->curl_handle, CURLOPT_HTTPGET, true);
+        }
+
+        curl_setopt($this->curl_handle, CURLOPT_HEADER, 1);
+        curl_setopt($this->curl_handle, CURLOPT_RETURNTRANSFER, true);
+        
+        $this->response = curl_exec($this->curl_handle);
+
+        return $this->response !== false;
+    }
+
+    /**
+     * Returns curl response code
+     *
+     * @param $curl_handle
+     *
+     * @return int
+     */
+    public function getResponseCode()
+    {
+        if ($this->curl_handle === null) {
+            return 0;
+        } else {
+            return curl_getinfo($this->curl_handle, CURLINFO_HTTP_CODE);
+        }
+    }
+
+
+    /**
+     * Returns the error string if curl error
+     *
+     * @param $curl_handle
+     *
+     * @return string
+     */
+    public function getResponseError()
+    {
+        return curl_error($this->curl_handle);
+    }
+
+    /**
+     * Returns the header from the curl response
+     *
+     * @param $curl_handle
+     * @param $response
+     *
+     * @return array
+     */
+    private function getResponseHeaders()
+    {
+        $header_size = $this->curlHeaderSize($this->curl_handle);
+
+        return explode(PHP_EOL, substr($this->response, 0, $header_size));
+    }
+
+    /**
+     * Returns the body element of the response object
+     *
+     * @return string
+     */
+    private function getResponseBody()
+    {
+        $body = '';
+        $header_size = $this->curlHeaderSize($this->curl_handle);
+        if (!empty($this->response)) {
+            $body = substr($this->response, $header_size);
+            if ($this->checkForZip($body)) {
+                $body = gzinflate(substr($body, 10, -8));
+            }
+        }
+
+        return $body;
+    }
+
+    /**
+     * Returns the associative array response or the error message
+     *
+     * @return mixed
+     */
+    public function getResponse()
+    {
+        if ($this->response !== false) {
+            $response = [ 'headers' => $this->headersToArray() ];
+            $responseBody = $this->getResponseBody();
+            if (empty($responseBody)) {
+                $response = array_merge($response, [ 'body' => 'empty' ]); 
+            } else {
+                $response = array_merge($response, json_decode($this->getResponseBody(), true));
+            }
+        } else {
+            $response = $this->getResponseError();
+        }
+
+        return $response;
+    }
+
+
+    /**
+     * function headersToArray
+     *
+     * Converts the http response header string to an associative array
+     *
+     * @param $headers
+     *
+     * @returns associative array of headers
+     */
+    private function headersToArray()
+    {
+        $headers = $this->getResponseHeaders();
+        $array_headers = array();
+        foreach ($headers as $k=>$v) {
+            $t = explode(':', $v, 2);
+            if (isset($t[1])) {
+                $array_headers[ trim($t[0]) ] = trim($t[1]);
+            } else {
+                if (strlen(trim($v)) > 0) {
+                    $array_headers[] = $v;
+                }
+                if (preg_match("#HTTP/[0-9\.]+\s+([0-9]+)#", $v, $out)) {
+                    $array_headers['response_code'] = intval($out[1]);
+                }
+            }
+        }
+        return $array_headers;
+    }
+
+    /**
+     * Checks for the signature values of gzip and bzip2
+     *
+     * @param $content
+     *
+     * @return bool
+     */
+    private function checkForZip($content)
+    {
+        $result = false;
+
+        if (strlen($content) > 3) {
+            if (bin2hex(substr($content, 0, 2)) == '1f8b') {
+                $result = true;
+            } elseif (substr($content, 0, 3) == 'BZh') {
+                $result = true;
+            }
+        }
+
+        return $result;
+    }
+    /**
+     * Returns the curl header size
+     *
+     * @param $curl_handle
+     *
+     * @return int
+     */
+    private function curlHeaderSize($curl_handle)
+    {
+        if ($curl_handle === null) {
+            return 0;
+        } else {
+            return curl_getinfo($curl_handle, CURLINFO_HEADER_SIZE);
+        }
+    }
+}

--- a/spec/rosette/api/ApiSpec.php
+++ b/spec/rosette/api/ApiSpec.php
@@ -46,41 +46,81 @@ class ApiSpec extends ObjectBehavior
         $this->getDebug()->shouldBe($debug);
     }
 
-    public function it_can_ping()
+    public function it_can_ping($request)
     {
+        $request->beADoubleOf('rosette\api\RosetteRequest');
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->getResponseCode()->willReturn(200);
+        $request->getResponse()->willReturn([ 'name' => 'Rosette API' ]);
+
+        $this->setMockRequest($request);
         $this->ping()->shouldHaveKeyWithValue('name', 'Rosette API');
     }
 
-    public function it_gets_info()
+    public function it_gets_info($request)
     {
+        $request->beADoubleOf('rosette\api\RosetteRequest');
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->getResponseCode()->willReturn(200);
+        $request->getResponse()->willReturn([ 'name' => 'Rosette API' ]);
+
+        $this->setMockRequest($request);
         $this->info()->shouldHaveKeyWithValue('name', 'Rosette API');
     }
 
-    public function it_calls_the_language_endpoint($params)
+    public function it_calls_the_language_endpoint($params, $request)
     {
         $params->beADoubleOf('\rosette\api\DocumentParameters');
         $params->content = 'Sample Data';
+
+        $request->beADoubleOf('rosette\api\RosetteRequest');
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->getResponseCode()->willReturn(200);
+        $request->getResponse()->willReturn([ 'name' => 'Rosette API', 'versionChecked' => true ]);
+
+        $this->setMockRequest($request);
         $this->language($params)->shouldHaveKeyWithValue('name', 'Rosette API');
     }
 
-    public function it_calls_the_sentences_endpoint($params)
+    public function it_calls_the_sentences_endpoint($params, $request)
     {
         $params->beADoubleOf('\rosette\api\DocumentParameters');
         $params->content = 'Sample Data';
+
+        $request->beADoubleOf('rosette\api\RosetteRequest');
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->getResponseCode()->willReturn(200);
+        $request->getResponse()->willReturn([ 'name' => 'Rosette API', 'versionChecked' => true ]);
+
+        $this->setMockRequest($request);
         $this->sentences($params)->shouldHaveKeyWithValue('name', 'Rosette API');
     }
 
-    public function it_calls_the_tokens_endpoint($params)
+    public function it_calls_the_tokens_endpoint($params, $request)
     {
         $params->beADoubleOf('\rosette\api\DocumentParameters');
         $params->content = 'Sample Data';
+
+        $request->beADoubleOf('rosette\api\RosetteRequest');
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->getResponseCode()->willReturn(200);
+        $request->getResponse()->willReturn([ 'name' => 'Rosette API', 'versionChecked' => true ]);
+
+        $this->setMockRequest($request);
         $this->tokens($params)->shouldHaveKeyWithValue('name', 'Rosette API');
     }
 
-    public function it_calls_the_morphology_endpoint($params)
+    public function it_calls_the_morphology_endpoint($params, $request)
     {
         $params->beADoubleOf('\rosette\api\DocumentParameters');
         $params->content = 'Sample Data';
+
+        $request->beADoubleOf('rosette\api\RosetteRequest');
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->getResponseCode()->willReturn(200);
+        $request->getResponse()->willReturn([ 'name' => 'Rosette API', 'versionChecked' => true ]);
+
+        $this->setMockRequest($request);
         $this->morphology($params)->shouldHaveKeyWithValue('name', 'Rosette API');
         $facet = 'lemmas';
         $this->morphology($params, $facet)->shouldHaveKeyWithValue('name', 'Rosette API');
@@ -92,87 +132,142 @@ class ApiSpec extends ObjectBehavior
         $this->morphology($params, $facet)->shouldHaveKeyWithValue('name', 'Rosette API');
     }
 
-    public function it_calls_the_entities_endpoint($params)
+    public function it_calls_the_entities_endpoint($params, $request)
     {
         $params->beADoubleOf('\rosette\api\DocumentParameters');
         $params->content = 'Sample Data';
+
+        $request->beADoubleOf('rosette\api\RosetteRequest');
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->getResponseCode()->willReturn(200);
+        $request->getResponse()->willReturn([ 'name' => 'Rosette API', 'versionChecked' => true ]);
+
+        $this->setMockRequest($request);
         $this->entities($params)->shouldHaveKeyWithValue('name', 'Rosette API');
+    }
+
+    public function it_calls_the_entities_linked_endpoint($params, $request)
+    {
+        $params->beADoubleOf('\rosette\api\DocumentParameters');
+        $params->content = 'Sample Data';
+
+        $request->beADoubleOf('rosette\api\RosetteRequest');
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->getResponseCode()->willReturn(200);
+        $request->getResponse()->willReturn([ 'name' => 'Rosette API', 'versionChecked' => true ]);
+
+        $this->setMockRequest($request);
         $linked = true;
         $this->entities($params, $linked)->shouldHaveKeyWithValue('name', 'Rosette API');
     }
 
-    public function it_calls_the_entities_linked_endpoint($params)
+    public function it_calls_the_categories_endpoint($params, $request)
     {
         $params->beADoubleOf('\rosette\api\DocumentParameters');
         $params->content = 'Sample Data';
-        $linked = true;
-        $this->entities($params, $linked)->shouldHaveKeyWithValue('name', 'Rosette API');
-    }
 
-    public function it_calls_the_categories_endpoint($params)
-    {
-        $params->beADoubleOf('\rosette\api\DocumentParameters');
-        $params->content = 'Sample Data';
+        $request->beADoubleOf('rosette\api\RosetteRequest');
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->getResponseCode()->willReturn(200);
+        $request->getResponse()->willReturn([ 'name' => 'Rosette API', 'versionChecked' => true ]);
+
+        $this->setMockRequest($request);
         $this->categories($params)->shouldHaveKeyWithValue('name', 'Rosette API');
     }
 
-    public function it_calls_the_sentiment_endpoint($params)
+    public function it_calls_the_sentiment_endpoint($params, $request)
     {
         $params->beADoubleOf('\rosette\api\DocumentParameters');
         $params->content = 'Sample Data';
+
+        $request->beADoubleOf('rosette\api\RosetteRequest');
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->getResponseCode()->willReturn(200);
+        $request->getResponse()->willReturn([ 'name' => 'Rosette API', 'versionChecked' => true ]);
+
+        $this->setMockRequest($request);
         $this->sentiment($params)->shouldHaveKeyWithValue('name', 'Rosette API');
     }
     
-    public function it_calls_using_multipart($params)
+    public function it_calls_using_multipart($params, $request)
     {
         $params->beADoubleOf('\rosette\api\DocumentParameters');
         $params->loadDocumentFile('fakefile');
+
+        $request->beADoubleOf('rosette\api\RosetteRequest');
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->getResponseCode()->willReturn(200);
+        $request->getResponse()->willReturn([ 'name' => 'Rosette API', 'versionChecked' => true ]);
+
+        $this->setMockRequest($request);
         $this->sentiment($params)->shouldHaveKeyWithValue('name', 'Rosette API');
     }
 
-    public function it_calls_the_name_translation_endpoint($params)
+    public function it_calls_the_name_translation_endpoint($params, $request)
     {
         $params->beADoubleOf('\rosette\api\NameTranslationParameters');
+
+        $request->beADoubleOf('rosette\api\RosetteRequest');
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->getResponseCode()->willReturn(200);
+        $request->getResponse()->willReturn([ 'name' => 'Rosette API', 'versionChecked' => true ]);
+
+        $this->setMockRequest($request);
         $this->nameTranslation($params)->shouldHaveKeyWithValue('name', 'Rosette API');
     }
 
-    public function it_calls_the_name_similarity_endpoint($params)
+    public function it_calls_the_name_similarity_endpoint($params, $request)
     {
         $params->beADoubleOf('\rosette\api\NameSimilarityParameters');
+
+        $request->beADoubleOf('rosette\api\RosetteRequest');
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->getResponseCode()->willReturn(200);
+        $request->getResponse()->willReturn([ 'name' => 'Rosette API', 'versionChecked' => true ]);
+
+        $this->setMockRequest($request);
         $this->nameSimilarity($params)->shouldHaveKeyWithValue('name', 'Rosette API');
     }
 
-    public function it_calls_the_relationships_endpoint($params)
+    public function it_calls_the_relationships_endpoint($params, $request)
     {
         $params->beADoubleOf('\rosette\api\RelationshipsParameters');
         $params->contentUri = 'http://some.dummysite.com';
+
+        $request->beADoubleOf('rosette\api\RosetteRequest');
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->getResponseCode()->willReturn(200);
+        $request->getResponse()->willReturn([ 'name' => 'Rosette API', 'versionChecked' => true ]);
+
+        $this->setMockRequest($request);
         $this->relationships($params)->shouldHaveKeyWithValue('name', 'Rosette API');
     }
-}
 
-namespace rosette\api;
+    public function it_fails_with_non_200_response($params, $request)
+    {
+        $params->beADoubleOf('\rosette\api\RelationshipsParameters');
+        $params->contentUri = 'http://some.dummysite.com';
 
-// mock the curl_exec call - return the version checked response to satisfy checkVersion
-function curl_exec($ch)
-{
-    // mock response
-    // Note: The X's are set to a length to make the header = 200, which is necessary to force a correct
-    //       boundary between the header and body.
-    $mock_response = 'HTTP/1.1 200 OK'.PHP_EOL;
-    $mock_response .= 'Content-Type: application/json'.PHP_EOL;
-    $mock_response .= 'Date: Thu, 31 Mar 2016 13:12:00 GMT'.PHP_EOL;
-    $mock_response .= 'Server: openresty/1.9.7.3'.PHP_EOL;
-    $mock_response .= 'X-RosetteAPI-Request-Id: XXXXXXXXXXXXXXXXXXXXXXXX'.PHP_EOL;
-    $mock_response .= 'Content-Length: 95'.PHP_EOL;
-    $mock_response .= 'Connection: keep-alive'.PHP_EOL;
-    $mock_response .= PHP_EOL;
-    $mock_response .= '{"name":"Rosette API","version":"0.10.3","buildNumber":"","buildTime":"","versionChecked":true}';
+        $request->beADoubleOf('rosette\api\RosetteRequest');
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->getResponseCode()->willReturn(403);
+        $request->getResponse()->willReturn([ 'message' => 'access to this resource denied', 'code' => 'forbidden' ]);
 
-    return $mock_response;
-}
+        $this->setMockRequest($request);
+        $this->shouldThrow('rosette\api\RosetteException')->duringRelationships($params);
+    }
 
-// mock the curl_getinfo call in order to return a valid code
-function curl_getinfo($ch)
-{
-    return 200;
+    public function it_fails_check_version($params, $request)
+    {
+        $params->beADoubleOf('\rosette\api\RelationshipsParameters');
+        $params->contentUri = 'http://some.dummysite.com';
+
+        $request->beADoubleOf('rosette\api\RosetteRequest');
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->getResponseCode()->willReturn(200);
+        $request->getResponse()->willReturn([ 'name' => 'Rosette API', 'versionChecked' => false ]);
+
+        $this->setMockRequest($request);
+        $this->shouldThrow('rosette\api\RosetteException')->duringRelationships($params);
+    }
 }

--- a/spec/rosette/api/CustomExceptionSpec.php
+++ b/spec/rosette/api/CustomExceptionSpec.php
@@ -17,7 +17,7 @@ class CustomExceptionSpec extends ObjectBehavior
         $message = 'test exception message';
         $code = 99;
         $this->beConstructedWith($message, $code);
-        $this->getMessage()->shouldBeLike($message);
+        $this->getMessage()->shouldBeLike("[${code}]: ${message}");
         $this->getCode()->shouldBeLike($code);
     }
 

--- a/spec/rosette/api/RosetteRequestSpec.php
+++ b/spec/rosette/api/RosetteRequestSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace spec\rosette\api;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class RosetteRequestSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $headers = array("X-RosetteAPI-Key: user_key",
+                          "Content-Type: application/json",
+                          "Accept: application/json",
+                          "Accept-Encoding: gzip",);
+        $this->beConstructedWith('https://api.rosette.com/rest/v1', null, $headers, 'GET');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('\rosette\api\RosetteRequest');
+    }
+
+    function it_sends_a_request()
+    {
+        $this->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->shouldBeBool();
+    }
+
+    function it_returns_a_code()
+    {
+        $this->getResponseCode()->shouldBeInteger();
+    }
+
+    function it_returns_a_response()
+    {
+        $this->getResponse()->shouldBeArray();
+    }
+
+}

--- a/spec/rosette/api/RosetteRequestSpec.php
+++ b/spec/rosette/api/RosetteRequestSpec.php
@@ -7,7 +7,7 @@ use Prophecy\Argument;
 
 class RosetteRequestSpec extends ObjectBehavior
 {
-    function let()
+    public function let()
     {
         $headers = array("X-RosetteAPI-Key: user_key",
                           "Content-Type: application/json",
@@ -16,24 +16,23 @@ class RosetteRequestSpec extends ObjectBehavior
         $this->beConstructedWith('https://api.rosette.com/rest/v1', null, $headers, 'GET');
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
         $this->shouldHaveType('\rosette\api\RosetteRequest');
     }
 
-    function it_sends_a_request()
+    public function it_sends_a_request()
     {
         $this->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())->shouldBeBool();
     }
 
-    function it_returns_a_code()
+    public function it_returns_a_code()
     {
         $this->getResponseCode()->shouldBeInteger();
     }
 
-    function it_returns_a_response()
+    public function it_returns_a_response()
     {
         $this->getResponse()->shouldBeArray();
     }
-
 }


### PR DESCRIPTION
- Refactor to facilitate 429 handling
- Unit tests improved, better mocking
- Added two new API properties, max_retries and milliseconds_between_retries
- Tested with 10 background processes all running examples, .5 second sleep on retry, no 429s
