### PR TITLE
Added check for user key existence

### DIFF
--- a/source/rosette/api/Api.php
+++ b/source/rosette/api/Api.php
@@ -343,7 +343,7 @@ class Api
             // should not get called due to makeRequest checks, but just in case, we want to 
             // avoid an incompatible version error when it's something else.
             if ($this->getResponseCode() !== 200) {
-                throw new RosetteException( $resultObject['message'], $this->getResponseCode());
+                throw new RosetteException($resultObject['message'], $this->getResponseCode());
             }
 
             if (array_key_exists('versionChecked', $resultObject) && $resultObject['versionChecked'] === true) {
@@ -380,7 +380,7 @@ class Api
         $request = $this->mock_request != null ? $this->mock_request : new RosetteRequest();
         for ($retries = 0; $retries < $this->max_retries; $retries++) {
             if ($request->makeRequest($url, $headers, $data, $method) === false) {
-                throw new RosetteException($request->getResponseError); 
+                throw new RosetteException($request->getResponseError);
             } else {
                 $this->setResponseCode($request->getResponseCode());
                 if ($this->getResponseCode() === 429) {

--- a/source/rosette/api/RosetteRequest.php
+++ b/source/rosette/api/RosetteRequest.php
@@ -198,7 +198,7 @@ class RosetteRequest
             $response = [ 'headers' => $this->headersToArray() ];
             $responseBody = $this->getResponseBody();
             if (empty($responseBody)) {
-                $response = array_merge($response, [ 'body' => 'empty' ]); 
+                $response = array_merge($response, [ 'body' => 'empty' ]);
             } else {
                 $response = array_merge($response, json_decode($this->getResponseBody(), true));
             }


### PR DESCRIPTION
Simple addition to check for the existence of a user key before adding the X-RosetteAPI-Key to the header.
