### PR TITLE
Updated to use the concurrency returned from Rosette API

### DIFF
--- a/source/rosette/api/Api.php
+++ b/source/rosette/api/Api.php
@@ -97,13 +97,6 @@ class Api
     private $ms_between_retries;
 
     /**
-     * request override - for testing
-     *
-     * @RosetteRequest
-     */
-    private $mock_request;
-
-    /**
      * internal options array
      * @var array
      */
@@ -115,6 +108,11 @@ class Api
      */
     private $customHeaders;
 
+    /**
+     * internal Request object
+     * @var array
+     */
+    private $request;
 
     /**
      * Create an L{API} object.
@@ -143,7 +141,7 @@ class Api
         $this->subUrl = null;
         $this->max_retries = 5;
         $this->ms_between_retries = 500000;
-        $this->mock_request = null;
+        $this->request = new RosetteRequest();
         $this->options = array();
     }
     
@@ -154,7 +152,7 @@ class Api
      */
     public function setMockRequest($requestObject)
     {
-        $this->mock_request = $requestObject;
+        $this->request = $requestObject;
     }
 
     /**
@@ -369,6 +367,17 @@ class Api
 
 
     /**
+     * Returns the max connections (concurrency)
+     *
+     * @return int
+     */
+    public function getMaxConnections()
+    {
+        return $this->request->getMaxConnections();
+    }
+
+
+    /**
      * Replaces a header item with a new one
      */
     private function replaceHeaderItem($old_header_item, $new_header_item)
@@ -448,25 +457,25 @@ class Api
      */
     private function makeRequest($url, $headers, $data, $method)
     {
-        $request = $this->mock_request != null ? $this->mock_request : new RosetteRequest();
         for ($retries = 0; $retries < $this->max_retries; $retries++) {
-            if ($request->makeRequest($url, $headers, $data, $method) === false) {
-                throw new RosetteException($request->getResponseError);
+            if ($this->request->makeRequest($url, $headers, $data, $method) === false) {
+                throw new RosetteException($this->request->getResponseError);
             } else {
-                $this->setResponseCode($request->getResponseCode());
+                $this->setResponseCode($this->request->getResponseCode());
                 if ($this->getResponseCode() === 429) {
+                    print('429 RETRY');
                     usleep($this->ms_between_retries);
                     continue;
                 } elseif ($this->getResponseCode() !== 200) {
-                    throw new RosetteException($request->getResponse()['message'], $this->getResponseCode());
+                    throw new RosetteException($this->request->getResponse()['message'], $this->getResponseCode());
                 }
-                return $request->getResponse();
+                return $this->request->getResponse();
             }
         }
         if ($this->getResponseCode() !== 200) {
-            throw new RosetteException($request->getResponse()['message'], $this->getResponseCode());
+            throw new RosetteException($this->request->getResponse()['message'], $this->getResponseCode());
         } else {
-            return $request->getResponse();
+            return $this->request->getResponse();
         }
     }
 
@@ -607,24 +616,25 @@ class Api
         return $this->callEndpoint($params, 'morphology/' . $facet);
     }
 
-      /* Calls the entities endpoint.
-      *
-      * @param $params
-      * @param $resolve_entities
-      *
-      * @return mixed
-      *
-      * @throws RosetteException
-      */
-      public function entities($params, $resolve_entities = false)
-     {
+    /** 
+     * Calls the entities endpoint.
+     *
+     * @param $params
+     * @param $resolve_entities
+     *
+     * @return mixed
+     *
+     * @throws RosetteException
+     */
+    public function entities($params, $resolve_entities = false)
+    {
         if ($resolve_entities == true) {
             error_reporting(E_DEPRECATED);
             return $this->callEndpoint($params, 'entities/linked');
         } else {
             return $this->callEndpoint($params, 'entities');
         }
-     }
+    }
 
 
     /**

--- a/spec/rosette/api/ApiSpec.php
+++ b/spec/rosette/api/ApiSpec.php
@@ -1,7 +1,9 @@
 <?php
 namespace spec\rosette\api;
+
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+
 class ApiSpec extends ObjectBehavior
 {
     public function let()
@@ -50,6 +52,10 @@ class ApiSpec extends ObjectBehavior
         $debug = false;
         $this->setDebug($debug);
         $this->getDebug()->shouldBe($debug);
+    }
+    public function it_gets_max_connections()
+    {
+        $this->getMaxConnections()->shouldBe(1);
     }
     public function it_can_ping($request)
     {

--- a/spec/rosette/api/RosetteRequestSpec.php
+++ b/spec/rosette/api/RosetteRequestSpec.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace spec\rosette\api;
 
 use PhpSpec\ObjectBehavior;
@@ -7,15 +6,6 @@ use Prophecy\Argument;
 
 class RosetteRequestSpec extends ObjectBehavior
 {
-    public function let()
-    {
-        $headers = array("X-RosetteAPI-Key: user_key",
-                          "Content-Type: application/json",
-                          "Accept: application/json",
-                          "Accept-Encoding: gzip",);
-        $this->beConstructedWith('https://api.rosette.com/rest/v1', null, $headers, 'GET');
-    }
-
     public function it_is_initializable()
     {
         $this->shouldHaveType('\rosette\api\RosetteRequest');
@@ -34,5 +24,10 @@ class RosetteRequestSpec extends ObjectBehavior
     public function it_returns_a_response()
     {
         $this->getResponse()->shouldBeArray();
+    }
+
+    public function it_gets_max_connections()
+    {
+        $this->getMaxConnections()->shouldBe(1);
     }
 }


### PR DESCRIPTION
- Created API member RosetteRequest to persist for all calls on API instance
- Adjust maxConnections per concurrency if the values do not match
- Unit tests updated - passed
- Temporary functional test - passed
