### PR TITLE
Add "rmccue/requests" as a dependency or else using the api will thro…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,13 @@
       "name": "Basis Technology Corp",
       "homepage": "https://developer.rosette.com"
     }
-  ],
+  ],    
+  "require": {
+    "rmccue/requests": ">=1.0"
+  },
   "require-dev": {
     "friendsofphp/php-cs-fixer": ">=1.9",
-    "phpspec/phpspec": "~2.5",
-    "rmccue/requests": ">=1.0"
+    "phpspec/phpspec": "~2.5"
   },
   "config": {
     "bin-dir": "bin"

--- a/source/rosette/api/RosetteRequest.php
+++ b/source/rosette/api/RosetteRequest.php
@@ -17,6 +17,11 @@
  **/
 namespace rosette\api;
 
+use WpOrg\Requests\Requests;
+use WpOrg\Requests\Exception as RequestsException;
+
+define('REQUESTS_SILENCE_PSR0_DEPRECATIONS', true);
+
 /**
  * Class RosetteRequest.
  *
@@ -76,12 +81,12 @@ class RosetteRequest
         }
         try {
             if ($method === 'POST') {
-                $this->response = \Requests::post($url, $headers, $data);
+                $this->response = Requests::post($url, $headers, $data);
             } elseif ($method === 'GET') {
-                $this->response = \Requests::get($url, $headers);
+                $this->response = Requests::get($url, $headers);
             }
             return true;
-        } catch (Requests_Exception $e) {
+        } catch (RequestsException $e) {
             throw new RosetteException($e->getMessage(), $e->getCode());
         }
     }


### PR DESCRIPTION
Add "rmccue/requests" as a dependency or else using the api will throw a class not found error.

Tested using the example code at https://developer.rosette.com/guide-start for PHP