### PR TITLE
WS-2589: Remove genre option from entities example

### DIFF
--- a/examples/entities.php
+++ b/examples/entities.php
@@ -18,7 +18,6 @@ $api = isset($options['url']) ? new Api($options['key'], $options['url']) : new 
 $params = new DocumentParameters();
 $content = $entities_text_data;
 $params->set('content', $content);
-$params->set('genre', 'social-media');
 
 try {
     $result = $api->entities($params);

--- a/source/rosette/api/DocumentParameters.php
+++ b/source/rosette/api/DocumentParameters.php
@@ -127,6 +127,9 @@ class DocumentParameters extends RosetteParamsSetBase
                 }
             }
         }
+        if (!empty(trim($this->genre))) {
+            error_log("Deprecated: The option 'genre' is deprecated and will be removed in the next release.", 0);
+        }
     }
 
     /**

--- a/source/rosette/api/DocumentParameters.php
+++ b/source/rosette/api/DocumentParameters.php
@@ -49,6 +49,7 @@ class DocumentParameters extends RosetteParamsSetBase
     private $fileName;
 
     /**
+     * @deprecated
      * @var string genre to categorize the input data
      */
     public $genre;

--- a/source/rosette/api/NameSimilarityParameters.php
+++ b/source/rosette/api/NameSimilarityParameters.php
@@ -31,6 +31,7 @@ class NameSimilarityParameters extends RosetteParamsSetBase
      */
     public $name2;
     /**
+     * @deprecated
      * @var string genre to categorize the input data
      */
     public $genre;

--- a/source/rosette/api/NameSimilarityParameters.php
+++ b/source/rosette/api/NameSimilarityParameters.php
@@ -67,5 +67,8 @@ class NameSimilarityParameters extends RosetteParamsSetBase
                 RosetteException::$BAD_REQUEST_FORMAT
             );
         }
+        if (!empty(trim($this->genre))) {
+            error_log("Deprecated: The option 'genre' is deprecated and will be removed in the next release.", 0);
+        }
     }
 }

--- a/source/rosette/api/NameTranslationParameters.php
+++ b/source/rosette/api/NameTranslationParameters.php
@@ -55,6 +55,7 @@ class NameTranslationParameters extends RosetteParamsSetBase
      */
     public $targetScheme;
     /**
+     * @deprecated
      * @var string genre to categorize the input data
      */
     public $genre;

--- a/source/rosette/api/NameTranslationParameters.php
+++ b/source/rosette/api/NameTranslationParameters.php
@@ -85,5 +85,8 @@ class NameTranslationParameters extends RosetteParamsSetBase
                 RosetteException::$BAD_REQUEST_FORMAT
             );
         }
+        if (!empty(trim($this->genre))) {
+            error_log("Deprecated: The option 'genre' is deprecated and will be removed in the next release.", 0);
+        }
     }
 }


### PR DESCRIPTION
This PR is needed to remove the genre fields from the entities example, and to mark it as `@deprecated` in the source code.