### PR TITLE
WS-3224: request timeout configurable

### DIFF
--- a/source/rosette/api/Api.php
+++ b/source/rosette/api/Api.php
@@ -123,6 +123,13 @@ class Api
     private $ms_between_retries;
 
     /**
+     * The maximum time in seconds to wait for the response to arrive
+     *
+     * @var null|int
+     */
+    private $timeout;
+
+    /**
      * Create an L{API} object.
      *
      * @param string $service_url URL of the Api API
@@ -147,6 +154,7 @@ class Api
         $this->options = array();
         $this->url_params = array();
         $this->customHeaders = array();
+        $this->timeout = null;
     }
 
     /**
@@ -194,6 +202,15 @@ class Api
     {
         $this->ms_between_retries = $ms_between_retries;
     }
+    /**
+      * Sets the maximum time in seconds to wait for the response to arrive
+      *
+      * @param int $timeout
+      */
+     public function setTimeout($timeout)
+     {
+         $this->timeout = $timeout;
+     }
 
     /**
      * Returns response code.
@@ -469,7 +486,7 @@ class Api
      */
     private function makeRequest($url, $headers, $data, $method)
     {
-        if ($this->request->makeRequest($url, $headers, $data, $method, $this->url_params) === false) {
+        if ($this->request->makeRequest($url, $headers, $data, $method, $this->timeout, $this->url_params) === false) {
             throw new RosetteException($this->request->getResponseError());
         } else {
             $this->setResponseCode($this->request->getResponseCode());

--- a/source/rosette/api/RosetteRequest.php
+++ b/source/rosette/api/RosetteRequest.php
@@ -72,18 +72,22 @@ class RosetteRequest
      *
      * @return bool
      */
-    public function makeRequest($url, $headers, $data, $method, $url_params = null)
+    public function makeRequest($url, $headers, $data, $method, $timeout, $url_params = null)
     {
         // Unfortunately, the 'options' argument for post and get is NOT for
         // query parameters (as it is in Python). Hence, the construction.
         if (!is_null($url_params)) {
             $url = $url . '?' . http_build_query($url_params);
         }
+        if (is_null($timeout)) {
+            $timeout = 30;
+        }
+        $options = ['timeout' => $timeout]; // Set the timeout here
         try {
             if ($method === 'POST') {
-                $this->response = Requests::post($url, $headers, $data);
+                $this->response = Requests::post($url, $headers, $data, $options);
             } elseif ($method === 'GET') {
-                $this->response = Requests::get($url, $headers);
+                $this->response = Requests::get($url, $headers, $options);
             }
             return true;
         } catch (RequestsException $e) {

--- a/spec/rosette/api/ApiSpec.php
+++ b/spec/rosette/api/ApiSpec.php
@@ -80,7 +80,7 @@ class ApiSpec extends ObjectBehavior
     public function it_can_ping($request)
     {
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField ]);
         $this->setMockRequest($request);
@@ -89,7 +89,7 @@ class ApiSpec extends ObjectBehavior
     public function it_gets_info($request)
     {
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField ]);
         $this->setMockRequest($request);
@@ -100,7 +100,7 @@ class ApiSpec extends ObjectBehavior
         $params->beADoubleOf(ApiSpec::$DocumentParametersFullClassName);
         $params->content = ApiSpec::$SampleContent;
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -111,7 +111,7 @@ class ApiSpec extends ObjectBehavior
         $params->beADoubleOf(ApiSpec::$DocumentParametersFullClassName);
         $params->content = ApiSpec::$SampleContent;
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -122,7 +122,7 @@ class ApiSpec extends ObjectBehavior
         $params->beADoubleOf(ApiSpec::$DocumentParametersFullClassName);
         $params->content = ApiSpec::$SampleContent;
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -133,7 +133,7 @@ class ApiSpec extends ObjectBehavior
         $params->beADoubleOf(ApiSpec::$DocumentParametersFullClassName);
         $params->content = ApiSpec::$SampleContent;
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -152,7 +152,7 @@ class ApiSpec extends ObjectBehavior
         $params->beADoubleOf(ApiSpec::$DocumentParametersFullClassName);
         $params->content = ApiSpec::$SampleContent;
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -163,7 +163,7 @@ class ApiSpec extends ObjectBehavior
         $params->beADoubleOf(ApiSpec::$DocumentParametersFullClassName);
         $params->content = ApiSpec::$SampleContent;
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -174,7 +174,7 @@ class ApiSpec extends ObjectBehavior
         $params->beADoubleOf(ApiSpec::$DocumentParametersFullClassName);
         $params->content = ApiSpec::$SampleContent;
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -185,7 +185,7 @@ class ApiSpec extends ObjectBehavior
         $params->beADoubleOf(ApiSpec::$DocumentParametersFullClassName);
         $params->content = ApiSpec::$SampleContent;
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -197,7 +197,7 @@ class ApiSpec extends ObjectBehavior
         $params->beADoubleOf(ApiSpec::$DocumentParametersFullClassName);
         $params->loadDocumentFile('fakefile');
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -207,7 +207,7 @@ class ApiSpec extends ObjectBehavior
     {
         $params->beADoubleOf('\rosette\api\NameTranslationParameters');
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -217,7 +217,7 @@ class ApiSpec extends ObjectBehavior
     {
         $params->beADoubleOf('\rosette\api\NameSimilarityParameters');
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -227,7 +227,7 @@ class ApiSpec extends ObjectBehavior
     {
         $params->beADoubleOf('\rosette\api\NameDeduplicationParameters');
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -237,7 +237,7 @@ class ApiSpec extends ObjectBehavior
     {
         $params->beADoubleOf('\rosette\api\RecordSimilarityParameters');
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -248,7 +248,7 @@ class ApiSpec extends ObjectBehavior
         $params->beADoubleOf(ApiSpec::$DocumentParametersFullClassName);
         $params->contentUri = ApiSpec::$DummyUri;
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -259,7 +259,7 @@ class ApiSpec extends ObjectBehavior
         $params->beADoubleOf(ApiSpec::$DocumentParametersFullClassName);
         $params->contentUri = ApiSpec::$DummyUri;
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -270,7 +270,7 @@ class ApiSpec extends ObjectBehavior
         $params->beADoubleOf(ApiSpec::$DocumentParametersFullClassName);
         $params->contentUri = ApiSpec::$DummyUri;
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -280,7 +280,7 @@ class ApiSpec extends ObjectBehavior
     {
         $params->beADoubleOf(ApiSpec::$DocumentParametersFullClassName);
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -291,7 +291,7 @@ class ApiSpec extends ObjectBehavior
         $params->beADoubleOf(ApiSpec::$DocumentParametersFullClassName);
         $params->content = ApiSpec::$SampleContent;
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -302,7 +302,7 @@ class ApiSpec extends ObjectBehavior
         $params->beADoubleOf(ApiSpec::$DocumentParametersFullClassName);
         $params->content = ApiSpec::$SampleContent;
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -312,7 +312,7 @@ class ApiSpec extends ObjectBehavior
     {
         $params->beADoubleOf('\rosette\api\AddressSimilarityParameters');
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(200);
         $request->getResponse()->willReturn([ 'name' => ApiSpec::$ResponseNameField]);
         $this->setMockRequest($request);
@@ -323,7 +323,7 @@ class ApiSpec extends ObjectBehavior
         $params->beADoubleOf(ApiSpec::$DocumentParametersFullClassName);
         $params->contentUri = ApiSpec::$DummyUri;
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(403);
         $request->getResponse()->willReturn([ 'message' => 'access to this resource denied', 'code' => 'forbidden' ]);
         $this->setMockRequest($request);
@@ -345,7 +345,7 @@ class ApiSpec extends ObjectBehavior
         $params->beADoubleOf(ApiSpec::$DocumentParametersFullClassName);
         $params->contentUri = ApiSpec::$DummyUri;
         $request->beADoubleOf(ApiSpec::$RosetteRequestFullClassName);
-        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
+        $request->makeRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $request->getResponseCode()->willReturn(409);
         $request->getResponse()->willReturn([ 'code' => 'incompatible version', 'message' => 'the version of client library used is not compatible with this server' ]);
         $this->setMockRequest($request);


### PR DESCRIPTION
Added configurable request timeout to the API objects. Also changed the default timeout from the 10 second that comes from the Requests library, to 30 seconds, in the hopes that it will stop random Jenkins build failures from occurring